### PR TITLE
Bugfix read from json file

### DIFF
--- a/job/job.go
+++ b/job/job.go
@@ -30,9 +30,9 @@ func (s Status) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.String())
 }
 
-func (s Status) UnmarshalJSON(b []byte) error {
+func (s *Status) UnmarshalJSON(b []byte) error {
 	var err error = nil
-	s, err = Parse(string(b))
+	*s, err = Parse(string(b))
 	return err
 }
 
@@ -54,9 +54,13 @@ func Parse(status string) (Status, error) {
 		return Failure, fmt.Errorf("Given status is empty.")
 	}
 
-	got, ok := map[string]Status{"failure": Failure, "unstable": Unstable, "success": Success}[strings.ToLower(status)]
+	// If the source of the received status is the JSON document, it contains quotation marks which have to be removed.
+	parsedStatus := strings.ToLower(strings.Replace(status, "\"", "", 2))
+	
+	got, ok := map[string]Status{"failure": Failure, "unstable": Unstable, "success": Success}[parsedStatus]
 	if !ok {
 		return Failure, fmt.Errorf("Given status %q is invalid.", status)
 	}
+
 	return got, nil
 }

--- a/job/job.go
+++ b/job/job.go
@@ -26,6 +26,10 @@ const (
 	Success                // Job compiled and all tests are green.
 )
 
+func (job Job) String() string {
+	return fmt.Sprintf("[%s:%s]", job.Name, job.Status);
+}
+
 func (s Status) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.String())
 }


### PR DESCRIPTION
I had to restart the service and came across this issue:

The parsing of the job status only works when send via HTTP from Jenkins. If the status is read from the JSON document, it is passed to the method with quotation marks - thus the status cannot be parsed.

In addition I also saw that even if the status is parsed correctly from the JSON file, it is not set on the status itself, because the method _UnmarshalJSON_ "works on a copy of the status", rather than being a 'normal, standard down to earth' method (not sure how you call this in GO....in my rather simple Java world I would say you had a static method there ;) ).