### PR TITLE
Add a parameter for the name of the LiFX bulb

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,13 @@ The buildbulb command will be available at ${GOPATH}/bin/.
 ## Usage
 
 ```shell
-./buildbulb --port=8080 --jobsFilePath=/path/to/load/and/persist/jobs
+./buildbulb --bulbName=BuildBulb --port=8080 --jobsFilePath=/path/to/load/and/persist/jobs
 ```
+
+All parameters are optional:
+- Default bulbName: BuildBulb
+- Default port: 8080
+- If jobsFilePath isn't set, the job status is lost when the program closes.
 
 Command line parameters to configure the application are work in progress.
 

--- a/light/controller.go
+++ b/light/controller.go
@@ -11,8 +11,8 @@ type Controller struct {
 	light *light
 }
 
-func NewController(input <-chan job.Status) (*Controller, error) {
-	light, err := newLight()
+func NewController(input <-chan job.Status, bulbName string) (*Controller, error) {
+	light, err := newLight(bulbName)
 	if err != nil {
 		return nil, err
 	}

--- a/light/light.go
+++ b/light/light.go
@@ -26,7 +26,7 @@ type light struct {
 	device common.Light
 }
 
-func newLight() (*light, error) {
+func newLight(bulbName string) (*light, error) {
 	// Get debug output for LIFX device
 	//logger := logrus.New()
 	//logger.Out = os.Stderr
@@ -39,9 +39,9 @@ func newLight() (*light, error) {
 	}
 	client.SetDiscoveryInterval(5 * time.Minute)
 
-	device, err := client.GetLightByLabel("BuildBulb")
+	device, err := client.GetLightByLabel(bulbName)
 	if err != nil {
-		util.Log.Error("Could not find any lamp with label 'BuildBulb'")
+		util.Log.Error("Could not find any lamp with label '" + bulbName + "'")
 		return nil, err
 	}
 	return &light{client, device}, nil

--- a/light/light_test.go
+++ b/light/light_test.go
@@ -10,7 +10,7 @@ const (
 )
 
 func TestLight(t *testing.T) {
-	l, err := newLight()
+	l, err := newLight("BuildBulb")
 	if err != nil {
 		t.Error(err)
 	}

--- a/server.go
+++ b/server.go
@@ -15,6 +15,7 @@ import (
 var (
 	port         = flag.Int("port", 8080, "port to listen for incoming HTTP requests")
 	jobsFilePath = flag.String("jobsFilePath", "", "path to load and persist jobs")
+	bulbName     = flag.String("bulbName", "", "name of the LiFX bulb to control")
 )
 
 func main() {
@@ -26,7 +27,7 @@ func main() {
 
 	notifier, notifications := notification.NewController()
 	jobifier, status := job.NewController(notifications, *jobsFilePath)
-	_, err := light.NewController(status)
+	_, err := light.NewController(status, *bulbName)
 
 	if err != nil {
 		util.Log.WithField("error", err).Fatal("Light controller threw an error on initialization.")


### PR DESCRIPTION
In order to use two different bulbs in the same networks (with different build jobs for each bulb), I added a new parameter "bulbName".